### PR TITLE
Fixes git clone path

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ http://downloads.vagrantup.com/tags/v1.2.2
 Two: Clone this repository.
 
 ```
-git clone https://github.com/bastosmichael/wp-chef.git
+git clone https://github.com/bastosmichael/WP-Chef.git
 ```
 
 Three: Install desired Vagrant Plugins


### PR DESCRIPTION
Because the capitalization of the git repo URL didn't match git threw the error, [git upload pack not found](http://stackoverflow.com/questions/15323268/git-upload-pack-not-found).
